### PR TITLE
Fix conv3 of ONet

### DIFF
--- a/src/get_nets.py
+++ b/src/get_nets.py
@@ -131,7 +131,7 @@ class ONet(nn.Module):
             ('prelu2', nn.PReLU(64)),
             ('pool2', nn.MaxPool2d(3, 2, ceil_mode=True)),
 
-            ('conv3', nn.Conv2d(64, 64, 2, 1)),
+            ('conv3', nn.Conv2d(64, 64, 3, 1)),
             ('prelu3', nn.PReLU(64)),
             ('pool3', nn.MaxPool2d(2, 2, ceil_mode=True)),
 


### PR DESCRIPTION
Kernel size of conv3 of ONet is 3x3 based on the original paper.

This pull request fixes the following bug:
1. Save the nets initialized by .npy files to a .pth file.
2. Remove weight initiation code (.npy).
3. Load the nets with the saved .pth file --> error message indicates that the kernel size of conv3 of ONet is mismatched.
